### PR TITLE
Fix prefix usages in ResX converter

### DIFF
--- a/LocalisationAnalyser/CodeFixes/LocaliseClassStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/LocaliseClassStringCodeFixProvider.cs
@@ -4,6 +4,7 @@
 using System.Composition;
 using LocalisationAnalyser.Abstractions.IO;
 using LocalisationAnalyser.Abstractions.IO.Default;
+using LocalisationAnalyser.Localisation;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 
@@ -15,8 +16,6 @@ namespace LocalisationAnalyser.CodeFixes
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LocaliseClassStringCodeFixProvider)), Shared]
     internal class LocaliseClassStringCodeFixProvider : AbstractLocaliseStringCodeFixProvider
     {
-        private const string class_suffix = "Strings";
-
         public LocaliseClassStringCodeFixProvider()
             : this(new DefaultFileSystem())
         {
@@ -27,6 +26,6 @@ namespace LocalisationAnalyser.CodeFixes
         {
         }
 
-        protected override string GetLocalisationFileName(string className) => $"{base.GetLocalisationFileName(className)}{class_suffix}";
+        protected override string GetLocalisationFileName(string className) => $"{base.GetLocalisationFileName(className)}{SyntaxTemplates.CLASS_STRINGS_FILE_SUFFIX}";
     }
 }

--- a/LocalisationAnalyser/CodeFixes/LocaliseCommonStringCodeFixProvider.cs
+++ b/LocalisationAnalyser/CodeFixes/LocaliseCommonStringCodeFixProvider.cs
@@ -4,6 +4,7 @@
 using System.Composition;
 using LocalisationAnalyser.Abstractions.IO;
 using LocalisationAnalyser.Abstractions.IO.Default;
+using LocalisationAnalyser.Localisation;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 
@@ -15,8 +16,6 @@ namespace LocalisationAnalyser.CodeFixes
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LocaliseCommonStringCodeFixProvider)), Shared]
     internal class LocaliseCommonStringCodeFixProvider : AbstractLocaliseStringCodeFixProvider
     {
-        private const string common_class_name = "Common";
-
         public LocaliseCommonStringCodeFixProvider()
             : this(new DefaultFileSystem())
         {
@@ -27,8 +26,8 @@ namespace LocalisationAnalyser.CodeFixes
         {
         }
 
-        protected override string GetLocalisationPrefix(string className) => common_class_name;
+        protected override string GetLocalisationPrefix(string className) => SyntaxTemplates.COMMON_STRINGS_FILE_NAME;
 
-        protected override string GetLocalisationFileName(string className) => common_class_name;
+        protected override string GetLocalisationFileName(string className) => SyntaxTemplates.COMMON_STRINGS_FILE_NAME;
     }
 }

--- a/LocalisationAnalyser/Localisation/SyntaxTemplates.cs
+++ b/LocalisationAnalyser/Localisation/SyntaxTemplates.cs
@@ -96,5 +96,15 @@ private static string {GET_KEY_METHOD_NAME}(string key) => $@""{{prefix}}:{{key}
             @$"{LICENSE_HEADER}
 
 using osu.Framework.Localisation;";
+
+        /// <summary>
+        /// The suffix attached to a class-specific localisation file name.
+        /// </summary>
+        public const string CLASS_STRINGS_FILE_SUFFIX = "Strings";
+
+        /// <summary>
+        /// The the common localisation file name.
+        /// </summary>
+        public const string COMMON_STRINGS_FILE_NAME = "Common";
     }
 }


### PR DESCRIPTION
- Don't add prefix to keys
- Don't add suffix to file names.
- Ignore non-localisation files (this namespace can contain unrelated files).